### PR TITLE
Fix examples directory instructions

### DIFF
--- a/examples/Makefile
+++ b/examples/Makefile
@@ -1,18 +1,28 @@
 minikube-create-arch:
 	sudo -E minikube start --driver=none --kubernetes-version v1.15.8 --extra-config kubeadm.ignore-preflight-errors=SystemVerification
 
-kind-create:
-	kind create cluster --name shipcat
+create-ns:
+	kubectl create namespace apps
 
 minikube:
 	kubectl config set-context --cluster=minikube --user=minikube --namespace=apps minikube
 	kubectl config use-context minikube
-	kubectl create namespace apps
+	$(MAKE) create-ns
 
-kind:
+minikube-cleanup:
+	minikube delete --all
+
+kind-create:
+	kind create cluster --name shipcat --image "kindest/node:v1.19.16"
+
+kind-cleanup:
+	kind delete cluster --name shipcat
+
+kind: kind-create
 	kubectl config use-context kind-shipcat
+	$(MAKE) create-ns
 
 integrations:
 	./integrations.sh
 
-.PHONY: integrations kind minikube
+.PHONY: integrations kind minikube create-ns

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -1,5 +1,5 @@
 minikube-create-arch:
-	sudo -E minikube start --driver=none --kubernetes-version v1.15.8 --extra-config kubeadm.ignore-preflight-errors=SystemVerification
+	sudo -E minikube start --driver=none --kubernetes-version v1.16.2 --extra-config kubeadm.ignore-preflight-errors=SystemVerification
 
 create-ns:
 	kubectl create namespace apps

--- a/examples/README.md
+++ b/examples/README.md
@@ -93,7 +93,7 @@ The `webapp` service relies on having a database. If you want to supply your own
 ```sh
 helm repo add bitnami https://charts.bitnami.com/bitnami
 helm repo update
-helm install postgresql bitnami/postgresql -n apps --create-namespace --set auth.password=pw --set auth.database=webapp
+helm install postgresql bitnami/postgresql -n apps --create-namespace --set image.tag=10.14.0 --set auth.password=pw --set auth.database=webapp
 ```
 
 Then we can write the external `DATABASE_URL` for `webapp`:

--- a/examples/README.md
+++ b/examples/README.md
@@ -18,6 +18,9 @@ A cluster defined in `shipcat.conf` (two example environments defined therein), 
 
 More examples in the `Makefile`.
 
+_Make sure the kubernetes version is lower than 1.22, since the `CRD` created by `shipcat` uses the
+`apiVersion: apiextensions.k8s.io/v1beta1` which was deprecated in `v1.16` and removed in `v1.22`_
+
 ### Example 1: Minikube
 A [minikube](https://github.com/kubernetes/minikube) [none driver](https://minikube.sigs.k8s.io/docs/reference/drivers/none/), running in the `apps` namespace:
 
@@ -28,14 +31,14 @@ kubectl create namespace apps
 ```
 
 ### Example 2: Kind
-A [kind](https://github.com/kubernetes-sigs/kind) cluster in the default namespace:
+A [kind](https://github.com/kubernetes-sigs/kind) cluster, configure the kube-context to work with `kind-shipcat` and create the `apps` namespace:
 
 ```sh
-kind create cluster --name shipcat
+make kind
 ```
 
 ## Installation
-The only thing you need to install are the CRDs that shipcat define, which can be done with:
+The only thing you need to install are the CRDs that `shipcat` define, which can be done with:
 
 ```sh
 shipcat cluster crd install
@@ -70,9 +73,11 @@ shipcat diff blog
 
 Note that the `webapp` example requires external dependencies which you can configure with `make integrations` or follow along below.
 
-
 ## Vault Integration
 Secrets are resolved from `vault`, so let's install a sample backend using `docker`:
+
+Requirements:
+- [vault CLI](https://developer.hashicorp.com/vault/tutorials/getting-started/getting-started-install)
 
 ```sh
 docker run --cap-add=IPC_LOCK -e 'VAULT_DEV_ROOT_TOKEN_ID=myroot' -e 'VAULT_DEV_LISTEN_ADDRESS=0.0.0.0:8200' -p 8200:8200 -d --rm --name vault vault:0.11.3
@@ -86,13 +91,15 @@ vault secrets enable -version=1 -path=secret kv
 The `webapp` service relies on having a database. If you want to supply your own working `DATABASE_URL` in vault further down, you can do so yourself. Here is how to do it with [helm 3](https://github.com/helm/helm/releases):
 
 ```sh
-helm install --set postgresqlPassword=pw,postgresqlDatabase=webapp -n=webapp-pg stable/postgresql
+helm repo add bitnami https://charts.bitnami.com/bitnami
+helm repo update
+helm install postgresql bitnami/postgresql -n apps --create-namespace --set auth.password=pw --set auth.database=webapp
 ```
 
 Then we can write the external `DATABASE_URL` for `webapp`:
 
 ```sh
-vault write secret/example/webapp/DATABASE_URL value=postgres://postgres:pw@webapp-pg-postgresql.apps/webapp
+vault write secret/example/webapp/DATABASE_URL value=postgres://postgres:pw@postgresql.apps.svc.cluster.local:5432/webapp
 ```
 
 You can verify that `shipcat` picks up on this via: `shipcat values -s webapp`.
@@ -150,3 +157,10 @@ shipcat cluster check
 shipcat secret verify-region -r minikube --changed=blog,webapp
 shipcat template webapp | kubeval -v 1.13.8 --strict
 ```
+
+## Clean up
+
+Once you're done, you can remove the k8s cluster:
+
+- Minikube: `make minikube-cleanup`
+- Kind: `make kind-cleanup`

--- a/examples/charts/base/templates/deployment.yaml
+++ b/examples/charts/base/templates/deployment.yaml
@@ -37,7 +37,7 @@ spec:
 {{- end }}
     spec:
       serviceAccountName: {{ .Values.name }}
-      #imagePullSecrets:
+      imagePullSecrets: []
       containers:
       - name: {{ .Values.name }}
         image: "{{ .Values.image }}:{{ .Values.version }}"
@@ -92,17 +92,16 @@ spec:
         hostAliases:
 {{ toYaml .Values.hostAliases | indent 10 }}
 {{- end }}
-
         env:
-        {{- include "container-env" (merge (dict "root" $) .Values.env) | trim | nindent 8 }}
-        - name: SERVICE_NAME
-          value: {{ .Values.name }}
-        - name: ENV_NAME
-          value: {{ .Values.environment }}
-        - name: REGION_NAME
-          value: {{ .Values.region }}
-        - name: SERVICE_VERSION
-          value: {{ .Values.version }}
+        {{- include "container-env" (merge (dict "root" $) .Values.env) | trim | nindent 10 -}}
+          - name: SERVICE_NAME
+            value: {{ .Values.name }}
+          - name: ENV_NAME
+            value: {{ .Values.environment }}
+          - name: REGION_NAME
+            value: {{ .Values.region }}
+          - name: SERVICE_VERSION
+            value: {{ .Values.version }}
 {{ if .Values.kafka }}
   {{- if .Values.kafka.mountPodIp }}
         - name: HOST_NAME

--- a/examples/charts/base/templates/service.yaml
+++ b/examples/charts/base/templates/service.yaml
@@ -16,7 +16,7 @@ spec:
     targetPort: {{ .Values.httpPort }}
     protocol: TCP
     name: http
-{{- if (.Values.health.port) and (not (eq .Values.health.port .Values.httpPort)) }}
+{{- if and (.Values.health.port) (not (eq .Values.health.port .Values.httpPort)) }}
   - port: {{ .Values.health.port }}
     protocol: TCP
     name: health

--- a/examples/integration.sh
+++ b/examples/integration.sh
@@ -12,6 +12,8 @@ vault secrets disable secret
 vault secrets enable -version=1 -path=secret kv
 
 # Start a database for the webapp service
-helm --namespace=apps install --set postgresqlPassword=pw,postgresqlDatabase=webapp -n=webapp-pg stable/postgresql
+helm repo add bitnami https://charts.bitnami.com/bitnami
+helm repo update
+helm install postgresql bitnami/postgresql -n apps --create-namespace --set auth.password=pw --set auth.database=webapp
 # Write its database password in vault
-vault write secret/minikube/webapp/DATABASE_URL value=postgres://postgres:pw@webapp-pg-postgresql.apps/webapp
+vault write secret/webapp/DATABASE_URL value=postgres://postgres:pw@postgresql.apps.svc.cluster.local:5432/webapp

--- a/examples/integration.sh
+++ b/examples/integration.sh
@@ -14,6 +14,6 @@ vault secrets enable -version=1 -path=secret kv
 # Start a database for the webapp service
 helm repo add bitnami https://charts.bitnami.com/bitnami
 helm repo update
-helm install postgresql bitnami/postgresql -n apps --create-namespace --set auth.password=pw --set auth.database=webapp
+helm install postgresql bitnami/postgresql -n apps --create-namespace --set image.tag=10.14.0 --set auth.password=pw --set auth.database=webapp
 # Write its database password in vault
 vault write secret/webapp/DATABASE_URL value=postgres://postgres:pw@postgresql.apps.svc.cluster.local:5432/webapp

--- a/examples/shipcat.conf
+++ b/examples/shipcat.conf
@@ -1,3 +1,7 @@
+defaults:
+  chart: base
+  replicaCount: 1
+
 clusters:
   minikube:
     name: minikube
@@ -8,7 +12,7 @@ clusters:
     name: kind
     api: http://localhost
     regions:
-    - kind-shipcat
+    - kind
 
 contextAliases:
   kind-shipcat: kind
@@ -27,7 +31,7 @@ regions:
 - name: kind
   environment: example
   cluster: kind
-  namespace: default
+  namespace: apps
   versioningScheme: Semver
   vault:
     url: http://localhost:8200

--- a/examples/shipcat.conf
+++ b/examples/shipcat.conf
@@ -11,7 +11,7 @@ clusters:
     - kind-shipcat
 
 contextAliases:
-  kind: kind-shipcat
+  kind-shipcat: kind
 
 regions:
 - name: minikube


### PR DESCRIPTION
# Description

Fix the instructions in the [examples](https://github.com/FernandoArteaga/shipcat/tree/master/examples) directory for being able to deploy locally the [blog](https://github.com/FernandoArteaga/shipcat/tree/master/examples/services/blog) and [webapp](https://github.com/FernandoArteaga/shipcat/tree/master/examples/services/webapp) services within a Kubernetes cluster (using `kind`).

## Changes

- Added target k8s version (`v1.19.16`) to the instructions to create a kind cluster. This was needed for supporting the CRD  created by `shipcat`, since they used an already removed APIVersion (`apiextensions.k8s.io/v1beta1`). It's not possible to use the APIVersion `apiextensions.k8s.io/v1` since there are missing fields that are required
- Added target Postgres version (`v10.14.0`) because the `webapp` database connector doesn't work with higher versions (authentications issues with psql)
  ```console
  thread 'main' panicked at 'db pool: Error(Some("SCRAM authentication requires libpq version 10 or above\n"))', libcore/result.
  ```
- Fixed some errors in the base Helm chart.
- Fixed kube-context alias configuration in the `shipcat.conf` file, which was misconfigured for `kind`

## Enhancements

- Added more targets to the `Makefile`:
  - Create a kind cluster with a good k8s version
  - Setup the kubeconfig and namespace to work with both `kind` and `minikube`
  - Cleanup work environment for `kind` and `minikube`
- Improve the Readme file by adding missing requirements and more description about the `kind` configuration
- Added the [bitnami/postgresql Helm chart](https://artifacthub.io/packages/helm/bitnami/postgresql) for installing Postgres

## Tested

Run the `blog` and `webapp` locally using kind for configuring a Kubernetes cluster

![clux-blog](https://github.com/FernandoArteaga/shipcat/assets/25615270/a7552d2a-051c-4268-9cc7-c0b8b458c771)

![clux-posts](https://github.com/FernandoArteaga/shipcat/assets/25615270/62985c98-e071-4b4b-b636-2a33a602069d)
